### PR TITLE
Remove text distortion workaround when debugging game on macOS

### DIFF
--- a/src/text.c
+++ b/src/text.c
@@ -61,12 +61,6 @@ void initText(Renderer *renderer)
 		1.0f, 1.0f
 	};
 	
-#if PLATFORM_APPLE && _DEBUG
-	// Work around issue where text is distorted while debugging on some machines via Xcode by ignoring the first created vertex buffer.
-	// This is not a game bug.
-	createVertexAndTextureCoordinateArrayObject(renderer, verticesAndTextureCoordinates, 16 * sizeof(*verticesAndTextureCoordinates), 8 * sizeof(*verticesAndTextureCoordinates));
-#endif
-	
 	gFontVertexAndTextureBufferObject = createVertexAndTextureCoordinateArrayObject(renderer, verticesAndTextureCoordinates, 16 * sizeof(*verticesAndTextureCoordinates), 8 * sizeof(*verticesAndTextureCoordinates));
 	
 	gFontIndicesBufferObject = rectangleIndexBufferObject(renderer);


### PR DESCRIPTION
I don't think this is needed anymore(?) but I'm not entirely sure. Leaving it here as a TODO until I can confidently decide I don't need this workaround.